### PR TITLE
Update zypper.py

### DIFF
--- a/plugins/modules/packaging/os/zypper.py
+++ b/plugins/modules/packaging/os/zypper.py
@@ -511,7 +511,9 @@ def repo_refresh(m):
 
 
 def transactional_updates():
-    return os.path.exists('/var/lib/misc/transactional-update.state')
+    return os.path.exists('/var/lib/misc/transactional-update.state') or \
+           os.path.exists('/sbin/transactional-update') or \
+           os.path.exists('/bin/tukit')
 
 # ===========================================
 # Main control flow


### PR DESCRIPTION
add more checks for t-u

Example: A newly created cloud server is lacking the file in /var/lib. This causes the module to use zypper and fail.